### PR TITLE
Fix error when cleaning nested generic type.

### DIFF
--- a/Runtime/EditorExtensions.cs
+++ b/Runtime/EditorExtensions.cs
@@ -19,7 +19,11 @@ namespace Leopotam.EcsLite.UnityEditor {
             foreach (var constraint in type.GetGenericArguments ()) {
                 constraints += constraints.Length > 0 ? $", {GetCleanGenericTypeName (constraint)}" : constraint.Name;
             }
-            return $"{type.Name.Substring (0, type.Name.LastIndexOf ("`", StringComparison.Ordinal))}<{constraints}>";
+            var genericIndex = type.Name.LastIndexOf ("`", StringComparison.Ordinal);
+            var typeName = genericIndex == -1
+                ? type.Name
+                : type.Name.Substring (0, genericIndex);
+            return $"{typeName}<{constraints}>";
         }
     }
 


### PR DESCRIPTION
Types like `Foo<T>.Bar` would fail due to their `Type.Name` not featuring a backtick character.

Now rendered as `Bar<T>`.

Error:
```
ArgumentOutOfRangeException: Length cannot be less than zero.
Parameter name: length
System.String.Substring (System.Int32 startIndex, System.Int32 length) (at <695d1cc93cca45069c528c15c9fdd749>:0)
Leopotam.EcsLite.UnityEditor.EditorExtensions.GetCleanGenericTypeName (System.Type type) (at C:/Users/rhysv/Projects/ecslite-unityeditor/Runtime/EditorExtensions.cs:22)
Leopotam.EcsLite.UnityEditor.EditorExtensions.GetCleanGenericTypeName (System.Type type) (at C:/Users/rhysv/Projects/ecslite-unityeditor/Runtime/EditorExtensions.cs:20)
Leopotam.EcsLite.UnityEditor.EcsWorldDebugSystem.Run (Leopotam.EcsLite.EcsSystems systems) (at C:/Users/rhysv/Projects/ecslite-unityeditor/Runtime/EcsWorldDebugSystem.cs:57)
Leopotam.EcsLite.EcsSystems.Run () (at Library/PackageCache/com.leopotam.ecslite@2022.3.22/src/systems.cs:166)
```